### PR TITLE
Added a placeholder for poster images to avoid layout shift

### DIFF
--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -26,7 +26,7 @@
 }
 
 .box .poster{
-    background: #2f33368a;
+    background-color: #2f33368a;
     background-size: cover;
     background-repeat: no-repeat;
     border-radius: 10px;

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -21,17 +21,23 @@
     margin-top: 15px;
     display: flex;
     align-items: center;
+    box-sizing: border-box;
+    padding: 15px;
 }
 
-.box img{
-    height: 160px;
-    max-width: 100px;
-    margin-left: 20px;
-    border-radius: 10px
+.box .poster{
+    background: #2f33368a;
+    background-size: cover;
+    background-repeat: no-repeat;
+    border-radius: 10px;
+    flex: 0 0 100px;
+    height: 150px;
 }
+
 .box .details{
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
     text-align: left;
     margin-left: 15px;
 }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -37,7 +37,7 @@ const Layout = ({ title, img, overview }) => {
     <div className='layout'>
       <div className="square">
         <div className="box">
-          <img src={`${base_url}${img}`} alt="logo" />
+          <div className='poster' role='img' aria-label='Poster' style={{backgroundImage: `url(${base_url}${img})`}}></div>
           <div className="details">
             <div className="heads">
               <h2>{title}</h2>


### PR DESCRIPTION
There are 3 minor changes in this PR.

1. In the current version the content continues to shift as the images get loaded. The content shift can be seen in this video,
[current.webm](https://github.com/Ankur1493/dekh-movie/assets/101462245/74e63b37-7b4a-453a-a154-2a676d9d72ee) This PR updates the markup of the Layout component to use a div with a background image instead. Using the div we can hold the space off for the image while it loads. The updated behaviour can be seen in this video, [updated.webm](https://github.com/Ankur1493/dekh-movie/assets/101462245/b53a7d40-26b7-4891-9258-690f83362083)

2. The height of the poster div was changed to 150px to make the aspect ratio same as the images returned from the API.
3. The box sizing was changed in the .box div to add some padding between the text and the right edge of the box. This difference has been demonstrated in the images below.

### Current
![current](https://github.com/Ankur1493/dekh-movie/assets/101462245/0fc8da9b-7688-4009-be80-8f6950f000bc)

### Updated
![updated](https://github.com/Ankur1493/dekh-movie/assets/101462245/2c97e9bf-5b93-4efd-8aea-2b7698e5d7d6)
